### PR TITLE
byPatternにwatchTargetsオプションを追加した

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Define compile task by pattern
 | options | Object |  Optional settings |
 | options.pattern | string&amp;#124;string[] |  File name pattern |
 | options.watchDelay | number |  Delay after watch |
+| options.watchTargets | string[] |  Additional watch targets |
 | options.namer | function |  Filename convert function |
 
 

--- a/lib/by_pattern.js
+++ b/lib/by_pattern.js
@@ -7,6 +7,7 @@
  * @param {Object} [options={}] - Optional settings
  * @param {string|string[]} [options.pattern] - File name pattern
  * @param {number} [options.watchDelay=100] - Delay after watch
+ * @param {string[]} [options.watchTargets=[]] - Additional watch target filenames
  * @param {function} [options.namer] - Filename convert function
  */
 'use strict'
@@ -22,7 +23,8 @@ function byPattern (srcDir, destDir, compiler, options = {}) {
   let {
     pattern = '**/*.*',
     namer = (filename) => filename,
-    watchDelay = 100
+    watchDelay = 100,
+    watchTargets = []
   } = options
 
   const resolvePaths = (filename) => ({
@@ -46,8 +48,12 @@ function byPattern (srcDir, destDir, compiler, options = {}) {
   return Object.assign(task,
     {
       watch: (ctx) => co(function * () {
+        let targets = [].concat(
+          watchTargets,
+          [].concat(pattern).map((pattern) => path.join(srcDir, pattern))
+        ).filter((filename, i, arr) => arr.indexOf(filename) === i)
         return watch(
-          [].concat(pattern).map((pattern) => path.join(srcDir, pattern)),
+          targets,
           (event, changed) => {
             let filename = path.relative(srcDir, changed)
             const { src, dest } = resolvePaths(filename)

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 /**
  * Pon task to compile file
  * @module pon-task-compile
- * @version 2.0.0
+ * @version 2.1.0
  */
 
 'use strict'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pon-task-compile",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Pon task to compile file",
   "main": "lib",
   "browser": "shim/browser",
@@ -26,7 +26,7 @@
     "aglob": "^2.0.1",
     "asfs": "^1.2.3",
     "co": "^4.6.0",
-    "pon-task-watch": "^2.0.1"
+    "pon-task-watch": "^2.0.2"
   },
   "devDependencies": {
     "ababel": "^2.0.1",


### PR DESCRIPTION
watch対象を任意で追加できるようにした。

以前はcompile対象のファイルだけをwatchしていたが、それだと依存先（import元)のファイルの変更での発火ができないため。